### PR TITLE
Bump AGP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,6 +3,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 # see https://gradle.org/release-checksums/
 distributionSha256Sum=23e7d37e9bb4f8dabb8a3ea7fdee9dd0428b9b1a71d298aefd65b11dccea220f


### PR DESCRIPTION
```
Execution failed for task ':app:mergeReleaseResources'.
> Multiple task action failures occurred:
   > A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
      > AAPT2 aapt2-4.1.3-6503028-linux Daemon #3: Unexpected error during compile '/home/vagrant/build/name.gdr.acastus_photon/app/src/main/res/mipmap-xxhdpi/ic_launcher.png', attempting to stop daemon.
        This should not happen under normal circumstances, please file an issue if it does.
   > A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
      > AAPT2 aapt2-4.1.3-6503028-linux Daemon #2: Unexpected error during compile '/home/vagrant/build/name.gdr.acastus_photon/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png', attempting to stop daemon.
        This should not happen under normal circumstances, please file an issue if it does.
   > A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
      > AAPT2 aapt2-4.1.3-6503028-linux Daemon #4: Unexpected error during compile '/home/vagrant/build/name.gdr.acastus_photon/app/src/main/res/drawable-xxhdpi/map_marker.png', attempting to stop daemon.
        This should not happen under normal circumstances, please file an issue if it does.
   > A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
      > AAPT2 aapt2-4.1.3-6503028-linux Daemon #5: Unexpected error during compile '/home/vagrant/build/name.gdr.acastus_photon/app/src/main/res/drawable-xxxhdpi/map_marker.png', attempting to stop daemon.
        This should not happen under normal circumstances, please file an issue if it does.
```

https://issuetracker.google.com/issues/184872412 This is an issue of AGP 4.1. Updating AGP to 4.2 or above should fix it.

ref: https://gitlab.com/fdroid/fdroiddata/-/commit/d0d4d9b37a9f63e025197bc3df701bd81d612c89